### PR TITLE
Fix sorting loops and string comparison messages

### DIFF
--- a/docNvim/Bubble_Sort/main.c
+++ b/docNvim/Bubble_Sort/main.c
@@ -54,7 +54,7 @@ void print_list(Student students[],int size){
 
 void sortBy_name(Student students[],int size){
     for (int i = 0; i < size - 1; i++) {
-        for (int j = 0; j - 1 - i ;j++) {
+        for (int j = 0; j < size - 1 - i; j++) {
             if (students[j].name[0] > students[j + 1].name[0]) {
                 Student temp = students[j];
                 students[j] = students[j + 1];

--- a/docNvim/lesson7_stringFunc/main.c
+++ b/docNvim/lesson7_stringFunc/main.c
@@ -10,6 +10,9 @@ int main(void){
         printf("strom!!");
     }
     else if(strcmp(string1,string2) > 0){
+        printf("s1 > string2");
+    }
+    else {
         printf("s1 < string2");
     }
 }


### PR DESCRIPTION
## Summary
- fix the loop condition in `sortBy_name` so all elements are compared
- correct string comparison message and handle `string1 < string2` case

## Testing
- `gcc docNvim/Bubble_Sort/main.c -o docNvim/Bubble_Sort/app`
- `./docNvim/Bubble_Sort/app | head -n 2`
- `gcc docNvim/lesson7_stringFunc/main.c -o docNvim/lesson7_stringFunc/app`
- `./docNvim/lesson7_stringFunc/app`


------
https://chatgpt.com/codex/tasks/task_e_68586f44369883248def394468568cd3